### PR TITLE
order optical element groups by id, so we can have the ordering Danie…

### DIFF
--- a/configdb3/hardware/models.py
+++ b/configdb3/hardware/models.py
@@ -109,6 +109,9 @@ class OpticalElementGroup(BaseModel):
     optical_elements = models.ManyToManyField(OpticalElement)
     element_change_overhead = models.FloatField(default=0)
 
+    class Meta:
+        ordering = ['id']
+
     def __str__(self):
         optical_elements_str = self.name + ' - ' + self.type + ': ' + self.optical_element_codes()
         return optical_elements_str


### PR DESCRIPTION
…l wants propogate through to obs portal

I know this is a bit hacky... but Daniel wants the diffuser_* optical element groups for muscat to display on the UI in a specific non-alphabetical order, and this way allows them to be displayed in the order you enter them into configdb in (their id), without changing any of the generic optical element view code. 

Without explicitly ordering by something, it's undefined what order the database returns, and it happens to not be what Daniel wants, and also is not alphabetical, so \_'-'_/