### PR TITLE
Configuration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ The application requires a PostgreSQL database backend because it uses JSONField
 
 This project is configured using environment variables.
 
-| Variable             | Description                                                                        | Default                      |
-| -------------------- | ---------------------------------------------------------------------------------- | ---------------------------- |
-| `SECRET_KEY`      | Django Secret Key                                                                  | `### CHANGE ME ###`          |
-| `DEBUG`         | Enable Django debugging features                                                                   | `False`          |
-| `DB_ENGINE`          | Database Engine, set to `django.db.backends.postgresql` to use PostgreSQL | `django.db.backends.postgresql` |
-| `DB_NAME`            | Database Name                                                                      | `configdb`                 |
-| `DB_HOST`            | Database Hostname, set this when using PostgreSQL                                  | `127.0.0.1`                |
-| `DB_USER`            | Database Username, set this when using PostgreSQL                                  | `postgres`               |
-| `DB_PASS`            | Database Password, set this when using PostgreSQL                                  |  `postgres`               |
-| `DB_PORT`            | Database Port, set this when using PostgreSQL                                      | `5432`                       |
-| `OAUTH_CLIENT_ID`            | Application client_id in the Observation Portal app                                   | `### CHANGE ME ###`                       |
-| `OAUTH_CLIENT_SECRET`            | Application client_secret in the Observation Portal app                                      | `### CHANGE ME ###`                       |
-| `OAUTH_TOKEN_URL`            | Observation Portal app                                      | `https://observation-portal-base-url/o/token/`                       |
+| Variable              | Description                                                                        | Default                         |
+| --------------------- | ---------------------------------------------------------------------------------- | ------------------------------- |
+| `SECRET_KEY`          | Django Secret Key, must be set                                                     | `### CHANGE ME ###`             |
+| `DEBUG`               | Enable Django debugging features, set to `True` for local development              | `False`                         |
+| `DB_ENGINE`           | Database Engine, set to `django.db.backends.postgresql` to use PostgreSQL          | `django.db.backends.postgresql` |
+| `DB_NAME`             | Database Name                                                                      | `configdb`                      |
+| `DB_HOST`             | Database Hostname, set this when using PostgreSQL                                  | `127.0.0.1`                     |
+| `DB_USER`             | Database Username, set this when using PostgreSQL                                  | `postgres`                      |
+| `DB_PASS`             | Database Password, set this when using PostgreSQL                                  | `postgres`                      |
+| `DB_PORT`             | Database Port, set this when using PostgreSQL                                      | `5432`                          |
+| `OAUTH_CLIENT_ID`     | OAuth2 application client_id, set this to use OAuth2 authentication                | `""`                            |
+| `OAUTH_CLIENT_SECRET` | OAuth2 application client_secret, set this to use OAuth2 authentication            | `""`                            |
+| `OAUTH_TOKEN_URL`     | OAuth2 token URL, set this to use OAuth2 authentication                            | `""`                            |
 
 ## Local Development
 
@@ -65,7 +65,12 @@ Run database migrations to set up the tables in the database.
 The application should now be accessible from <http://127.0.0.1:8000>!
 
 ### Authentication
-The application connects to a running Observation Portal for oauth2 authentication to access the admin interface. Staff accounts should have access to the admin interface. If no Observation Portal is connected during development, creating a local superuser account should work to access the admin interface as well:
+The application connects to a running Observation Portal for OAuth2 authentication. Staff accounts should have
+access to the admin interface. Remember to set the appropriate environment variables - the token url
+will be the `/o/token/` endpoint of the Observation Portal you are connecting to.
+
+If no Observation Portal is connected during development, creating a local superuser account should work to
+access the admin interface as well:
 
     (env) python manage.py createsuperuser
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project is configured using environment variables.
 
 | Variable              | Description                                                                        | Default                         |
 | --------------------- | ---------------------------------------------------------------------------------- | ------------------------------- |
-| `SECRET_KEY`          | Django Secret Key, must be set                                                     | `### CHANGE ME ###`             |
+| `SECRET_KEY`          | Django Secret Key, this value must be set to run the app                           | `None`                          |
 | `DEBUG`               | Enable Django debugging features, set to `True` for local development              | `False`                         |
 | `DB_ENGINE`           | Database Engine, set to `django.db.backends.postgresql` to use PostgreSQL          | `django.db.backends.postgresql` |
 | `DB_NAME`             | Database Name                                                                      | `configdb`                      |

--- a/configdb/auth_backends.py
+++ b/configdb/auth_backends.py
@@ -13,23 +13,24 @@ class OAuth2Backend(BaseBackend):
     def authenticate(self, request, username=None, password=None):
         if username == 'eng':
             return None  # anonymous eng account disabled
-        response = requests.post(
-            settings.OAUTH_TOKEN_URL,
-            data={
-                'grant_type': 'password',
-                'username': username,
-                'password': password,
-                'client_id': settings.OAUTH_CLIENT_ID,
-                'client_secret': settings.OAUTH_CLIENT_SECRET
-            }
-        )
-        if response.status_code == 200:
-            user, created = User.objects.get_or_create(
-                username=username,
-                is_superuser=True,
-                is_staff=True
+        if settings.OAUTH_TOKEN_URL:
+            response = requests.post(
+                settings.OAUTH_TOKEN_URL,
+                data={
+                    'grant_type': 'password',
+                    'username': username,
+                    'password': password,
+                    'client_id': settings.OAUTH_CLIENT_ID,
+                    'client_secret': settings.OAUTH_CLIENT_SECRET
+                }
             )
-            return user
+            if response.status_code == 200:
+                user, created = User.objects.get_or_create(
+                    username=username,
+                    is_superuser=True,
+                    is_staff=True
+                )
+                return user
         return None
 
     def get_user(self, user_id):

--- a/configdb/hardware/tests.py
+++ b/configdb/hardware/tests.py
@@ -13,25 +13,30 @@ from .serializers import GenericModeSerializer
 
 @patch('configdb.auth_backends.requests.post')
 class TestOauth2Login(TestCase):
+    def setUp(self) -> None:
+        self.credentials = {'username': 'bob', 'password': 'pass'}
+        self.oauth_token_url = 'localhost'
+        self.empty_oauth_token_url = ''
+
     def test_log_in(self, mock_post):
         mock_post.return_value.status_code = 200
-        with self.settings(OAUTH_TOKEN_URL='localhost'):
-            logged_in = self.client.login(username='bob', password='bobspass')
+        with self.settings(OAUTH_TOKEN_URL=self.oauth_token_url):
+            logged_in = self.client.login(**self.credentials)
             self.assertTrue(logged_in)
-            self.assertEqual(User.objects.filter(username='bob').count(), 1)
+            self.assertEqual(User.objects.filter(username=self.credentials['username']).count(), 1)
 
     def test_incorrect_login_credentials_fails(self, mock_post):
         mock_post.return_value.status_code = 403
-        with self.settings(OAUTH_TOKEN_URL='localhost'):
-            logged_in = self.client.login(username='bob', password='notbobspass')
+        with self.settings(OAUTH_TOKEN_URL=self.oauth_token_url):
+            logged_in = self.client.login(**self.credentials)
             self.assertFalse(logged_in)
-            self.assertEqual(User.objects.filter(username='bob').count(), 0)
+            self.assertEqual(User.objects.filter(username=self.credentials['username']).count(), 0)
 
     def test_log_in_with_no_oauth_url_set_fails(self, mock_post):
-        with self.settings(OAUTH_TOKEN_URL=''):
-            logged_in = self.client.login(username='bob', password='bobspass')
+        with self.settings(OAUTH_TOKEN_URL=self.empty_oauth_token_url):
+            logged_in = self.client.login(**self.credentials)
             self.assertFalse(logged_in)
-            self.assertEqual(User.objects.filter(username='bob').count(), 0)
+            self.assertEqual(User.objects.filter(username=self.credentials['username']).count(), 0)
 
 
 class SimpleHardwareTest(TestCase):

--- a/configdb/settings.py
+++ b/configdb/settings.py
@@ -105,7 +105,7 @@ DATABASES = {
         'ENGINE': os.getenv('DB_ENGINE', 'django.db.backends.postgresql'),
         'NAME': os.getenv('DB_NAME', 'configdb'),
         'USER': os.getenv('DB_USER', 'postgres'),
-        'PASSWORD': os.getenv('DB_PASS', ''),
+        'PASSWORD': os.getenv('DB_PASS', 'postgres'),
         'HOST': os.getenv('DB_HOST', '127.0.0.1'),
         'PORT': int(os.getenv('DB_PORT', 5432)),
     }

--- a/configdb/urls.py
+++ b/configdb/urls.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 from .hardware import urls as hardware_urls
 
@@ -7,3 +9,6 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^', include(hardware_urls))
 ]
+
+if settings.DEBUG:
+    urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Changes to make sure that the default variables in the README and the default values set in the settings file match up. I also made a couple of other changes that are useful for local development.
- Set the default database password to match the stated default in the README. Fixes https://github.com/observatorycontrolsystem/configdb/issues/16.
- Serve static files if `settings.DEBUG` is `True`. This is useful for local development.
- Check that the `OAUTH_TOKEN_URL` has been set in the `OAuth2Backend` class before sending a request to that url for authentication. This keeps the app from crashing when the OAuth environment variables have not been set.