### PR TITLE
Update destination directory in OCS GH pages.

### DIFF
--- a/.github/workflows/docs-gh-pages.yml
+++ b/.github/workflows/docs-gh-pages.yml
@@ -31,7 +31,7 @@ jobs:
         personal_token: ${{ secrets.PERSONAL_TOKEN }}
         external_repository: observatorycontrolsystem/observatorycontrolsystem.github.io
         publish_dir: docs
-        destination_dir: docs
+        destination_dir: assets/html
         enable_jekyll: true
         publish_branch: main
         keep_files: true


### PR DESCRIPTION
We no longer want to push the pre-built HTML docs to the docs/ directory, but rather the assets/html/ directory in the OCS GitHub pages project.

[Docs here](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-deploy-to-subdirectory-destination_dir)