### PR TITLE
Update the bin validation schema in the inite2e data command

### DIFF
--- a/configdb/hardware/management/commands/init_e2e_data.py
+++ b/configdb/hardware/management/commands/init_e2e_data.py
@@ -65,8 +65,10 @@ class Command(BaseCommand):
         readout_mode_type, _ = ModeType.objects.get_or_create(id='readout')
         readout_mode, _ = GenericMode.objects.get_or_create(code='default',
             defaults={'name': 'Sinistro Readout Mode', 'overhead': 0,
-                      'validation_schema': {"bin_x": {"type": "integer", "allowed": [1], "default": 1},
-                                            "bin_y": {"type": "integer", "allowed": [1], "default": 1}}
+                      'validation_schema': {"extra_params": {"type": "dict", "schema": {"bin_x":
+                                           {"type": "integer", "allowed": [1], "default": 1, "required": False},
+                                           "bin_y": {"type": "integer", "allowed": [1], "default": 1,
+                                           "required": False}}, "default": {}, "required": True}}
                      }
         )
 


### PR DESCRIPTION
This was never updated when we eliminated bin_x/bin_y from the instrument config models, so this will break things in the ocs_example when running with an up-to-date observation portal. It also contradicts our docs now!